### PR TITLE
CD-235478 Resque.redis with Resque::Worker redis

### DIFF
--- a/lib/resque-dynamic-queues.rb
+++ b/lib/resque-dynamic-queues.rb
@@ -8,3 +8,4 @@ require 'resque/plugins/dynamic_queues/queues'
 #end
 Resque.send(:extend, Resque::Plugins::DynamicQueues::Attributes)
 Resque::Worker.send(:include, Resque::Plugins::DynamicQueues::Queues)
+Resque::Worker.send(:include, Resque::Plugins::DynamicQueues::Attributes)

--- a/lib/resque/plugins/dynamic_queues/queues.rb
+++ b/lib/resque/plugins/dynamic_queues/queues.rb
@@ -21,7 +21,7 @@ module Resque
 
           return queues_without_dynamic if queue_names.grep(/(^!)|(^@)|(\*)/).size == 0
 
-          real_queues = Resque.queues
+          real_queues =  Array(redis.smembers(:queues)) # Here `redis` refers to the Resque::Worker's redis
           matched_queues = []
 
           while q = queue_names.shift
@@ -31,7 +31,7 @@ module Resque
               key = $2.strip
               key = hostname if key.size == 0
 
-              add_queues = Resque.get_dynamic_queue(key)
+              add_queues = get_dynamic_queue(key)
               add_queues.map! { |q| q.gsub!(/^!/, '') || q.gsub!(/^/, '!') } if $1
 
               queue_names.concat(add_queues)

--- a/lib/resque/plugins/dynamic_queues/queues.rb
+++ b/lib/resque/plugins/dynamic_queues/queues.rb
@@ -21,7 +21,7 @@ module Resque
 
           return queues_without_dynamic if queue_names.grep(/(^!)|(^@)|(\*)/).size == 0
 
-          real_queues =  Array(redis.smembers(:queues)) # Here `redis` refers to the Resque::Worker's redis
+          real_queues =  Array(self.class.redis.smembers(:queues)) # Here `self.class` refers to Resque::Worker
           matched_queues = []
 
           while q = queue_names.shift


### PR DESCRIPTION
## Reviewers

- [x] @johnny-lai 

## Summary of Change

**Backround**:  As a part of redis v6 change, we support mutiple resque workers - Resque::Worker(for redis v3), Resque::SSLWorker(for redis v6). Also these multiple resque workers talk to their own redis and not Resque.redis
Resque.redis will point to redis v3 or redis v6 depending on the config.

As per the above usecase, replace Resque.redis with worker specific redis.